### PR TITLE
Create the base CLI structures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ccupdater_cli_rs"
 version = "0.1.0"
-authors = ["Ignacio <nnubes256@gmail.com>"]
+authors = ["CCDirectLink Contributors"]
 license = "MIT"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ authors = ["CCDirectLink Contributors"]
 license = "MIT"
 
 [dependencies]
+clap = { version = "3.0.0-beta.1", git = "https://github.com/clap-rs/clap.git"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "CCUpdaterCLI-rs"
+name = "ccupdater_cli_rs"
 version = "0.1.0"
 authors = ["Ignacio <nnubes256@gmail.com>"]
 license = "MIT"

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1,0 +1,52 @@
+#[derive(Clap)]
+#[clap(version = "0.1", author = "CCDirectLink Contributors")]
+pub(crate) struct CLIBaseOptions {
+    #[clap(long = "game", default_value = ".", help = "Sets the game folder used for operations")]
+    pub(crate) game: String,
+    #[clap(subcommand)]
+    pub(crate) subcommand: CLISubcommand
+}
+
+#[derive(Clap)]
+#[clap(version = "0.1", author = "CCDirectLink Contributors")]
+pub(crate) enum CLISubcommand {
+    #[clap(name = "list", about = "List all the mods that the tool knows about")]
+    List(CLISubListOptions),
+    #[clap(name = "outdated", about = "Show the names and versions of outdated mods")]
+    Outdated(CLISubOutdatedOptions),
+    #[clap(name = "install", about = "Install one or more mods")]
+    Install(CLISubInstallOptions),
+    #[clap(name = "uninstall", about = "Uninstall one or more mods")]
+    Uninstall(CLISubUninstallOptions),
+    #[clap(name = "update", about = "Update one or more mods")]
+    Update(CLISubUpdateOptions),
+}
+
+#[derive(Clap)]
+#[clap(name = "list", version = "0.1", author = "CCDirectLink Contributors")]
+pub(crate) struct CLISubListOptions {}
+
+#[derive(Clap)]
+#[clap(name = "outdated", version = "0.1", author = "CCDirectLink Contributors")]
+pub(crate) struct CLISubOutdatedOptions {}
+
+#[derive(Clap)]
+#[clap(name = "install", version = "0.1", author = "CCDirectLink Contributors")]
+pub(crate) struct CLISubInstallOptions {
+    #[clap(help = "The mods to uninstall")]
+    pub(crate) mods: Vec<String>
+}
+
+#[derive(Clap)]
+#[clap(name = "uninstall", version = "0.1", author = "CCDirectLink Contributors")]
+pub(crate) struct CLISubUninstallOptions {
+    #[clap(help = "The mods to uninstall")]
+    pub(crate) mods: Vec<String>
+}
+
+#[derive(Clap)]
+#[clap(name = "update", version = "0.1", author = "CCDirectLink Contributors")]
+pub(crate) struct CLISubUpdateOptions {
+    #[clap(help = "The mods to uninstall", min_values = 0)]
+    pub(crate) mods: Vec<String>
+}

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1,4 +1,4 @@
-#[derive(Clap)]
+#[derive(Clap, Clone)]
 #[clap(version = "0.1", author = "CCDirectLink Contributors")]
 pub(crate) struct CLIBaseOptions {
     #[clap(long = "game", default_value = ".", help = "Sets the game folder used for operations")]
@@ -7,7 +7,7 @@ pub(crate) struct CLIBaseOptions {
     pub(crate) subcommand: CLISubcommand
 }
 
-#[derive(Clap)]
+#[derive(Clap, Clone)]
 #[clap(version = "0.1", author = "CCDirectLink Contributors")]
 pub(crate) enum CLISubcommand {
     #[clap(name = "list", about = "List all the mods that the tool knows about")]
@@ -22,29 +22,29 @@ pub(crate) enum CLISubcommand {
     Update(CLISubUpdateOptions),
 }
 
-#[derive(Clap)]
+#[derive(Clap, Clone)]
 #[clap(name = "list", version = "0.1", author = "CCDirectLink Contributors")]
 pub(crate) struct CLISubListOptions {}
 
-#[derive(Clap)]
+#[derive(Clap, Clone)]
 #[clap(name = "outdated", version = "0.1", author = "CCDirectLink Contributors")]
 pub(crate) struct CLISubOutdatedOptions {}
 
-#[derive(Clap)]
+#[derive(Clap, Clone)]
 #[clap(name = "install", version = "0.1", author = "CCDirectLink Contributors")]
 pub(crate) struct CLISubInstallOptions {
     #[clap(help = "The mods to uninstall")]
     pub(crate) mods: Vec<String>
 }
 
-#[derive(Clap)]
+#[derive(Clap, Clone)]
 #[clap(name = "uninstall", version = "0.1", author = "CCDirectLink Contributors")]
 pub(crate) struct CLISubUninstallOptions {
     #[clap(help = "The mods to uninstall")]
     pub(crate) mods: Vec<String>
 }
 
-#[derive(Clap)]
+#[derive(Clap, Clone)]
 #[clap(name = "update", version = "0.1", author = "CCDirectLink Contributors")]
 pub(crate) struct CLISubUpdateOptions {
     #[clap(help = "The mods to uninstall", min_values = 0)]

--- a/src/features/install.rs
+++ b/src/features/install.rs
@@ -1,0 +1,6 @@
+use cmd::CLISubInstallOptions;
+
+pub(crate) fn run(arguments: CLISubInstallOptions) -> i32 {
+    println!("Here goes install logic");
+    0
+}

--- a/src/features/install.rs
+++ b/src/features/install.rs
@@ -1,6 +1,7 @@
+use cmd::CLIBaseOptions;
 use cmd::CLISubInstallOptions;
 
-pub(crate) fn run(arguments: CLISubInstallOptions) -> i32 {
+pub(crate) fn run(top_args: CLIBaseOptions, sub_args: CLISubInstallOptions) -> i32 {
     println!("Here goes install logic");
     0
 }

--- a/src/features/list.rs
+++ b/src/features/list.rs
@@ -1,0 +1,6 @@
+use cmd::CLISubListOptions;
+
+pub(crate) fn run(arguments: CLISubListOptions) -> i32 {
+    println!("Here goes list logic");
+    0
+}

--- a/src/features/list.rs
+++ b/src/features/list.rs
@@ -1,6 +1,7 @@
+use cmd::CLIBaseOptions;
 use cmd::CLISubListOptions;
 
-pub(crate) fn run(arguments: CLISubListOptions) -> i32 {
+pub(crate) fn run(top_args: CLIBaseOptions, sub_args: CLISubListOptions) -> i32 {
     println!("Here goes list logic");
     0
 }

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -1,0 +1,5 @@
+pub mod list;
+pub mod outdated;
+pub mod install;
+pub mod uninstall;
+pub mod update;

--- a/src/features/outdated.rs
+++ b/src/features/outdated.rs
@@ -1,0 +1,6 @@
+use cmd::CLISubOutdatedOptions;
+
+pub(crate) fn run(arguments: CLISubOutdatedOptions) -> i32 {
+    println!("Here goes outdated logic");
+    0
+}

--- a/src/features/outdated.rs
+++ b/src/features/outdated.rs
@@ -1,6 +1,7 @@
+use cmd::CLIBaseOptions;
 use cmd::CLISubOutdatedOptions;
 
-pub(crate) fn run(arguments: CLISubOutdatedOptions) -> i32 {
+pub(crate) fn run(top_args: CLIBaseOptions, sub_args: CLISubOutdatedOptions) -> i32 {
     println!("Here goes outdated logic");
     0
 }

--- a/src/features/uninstall.rs
+++ b/src/features/uninstall.rs
@@ -1,0 +1,6 @@
+use cmd::CLISubUninstallOptions;
+
+pub(crate) fn run(arguments: CLISubUninstallOptions) -> i32 {
+    println!("Here goes uninstall logic");
+    0
+}

--- a/src/features/uninstall.rs
+++ b/src/features/uninstall.rs
@@ -1,6 +1,7 @@
+use cmd::CLIBaseOptions;
 use cmd::CLISubUninstallOptions;
 
-pub(crate) fn run(arguments: CLISubUninstallOptions) -> i32 {
+pub(crate) fn run(top_args: CLIBaseOptions, sub_args: CLISubUninstallOptions) -> i32 {
     println!("Here goes uninstall logic");
     0
 }

--- a/src/features/update.rs
+++ b/src/features/update.rs
@@ -1,0 +1,6 @@
+use cmd::CLISubUpdateOptions;
+
+pub(crate) fn run(arguments: CLISubUpdateOptions) -> i32 {
+    println!("Here goes update logic");
+    0
+}

--- a/src/features/update.rs
+++ b/src/features/update.rs
@@ -1,6 +1,7 @@
+use cmd::CLIBaseOptions;
 use cmd::CLISubUpdateOptions;
 
-pub(crate) fn run(arguments: CLISubUpdateOptions) -> i32 {
+pub(crate) fn run(top_args: CLIBaseOptions, sub_args: CLISubUpdateOptions) -> i32 {
     println!("Here goes update logic");
     0
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,12 +2,25 @@
 extern crate clap;
 
 mod cmd;
+mod features;
 
+use std::process;
 use cmd::CLIBaseOptions;
+use cmd::CLISubcommand;
 
 
 fn main() {
     let opts = CLIBaseOptions::parse();
 
     println!("Game base path has been set to: {}", opts.game);
+
+    let result: i32 = match opts.subcommand {
+        CLISubcommand::Install(args) => features::install::run(args),
+        CLISubcommand::Uninstall(args) => features::uninstall::run(args),
+        CLISubcommand::Update(args) => features::update::run(args),
+        CLISubcommand::List(args) => features::list::run(args),
+        CLISubcommand::Outdated(args) => features::outdated::run(args)
+    };
+
+    process::exit(result);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,13 @@
-// Example code
+#[macro_use]
+extern crate clap;
+
+mod cmd;
+
+use cmd::CLIBaseOptions;
+
 
 fn main() {
-    println!("Hello, world!");
+    let opts = CLIBaseOptions::parse();
+
+    println!("Game base path has been set to: {}", opts.game);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,16 +10,18 @@ use cmd::CLISubcommand;
 
 
 fn main() {
-    let opts = CLIBaseOptions::parse();
+    let top_args = CLIBaseOptions::parse();
 
-    println!("Game base path has been set to: {}", opts.game);
+    println!("Game base path has been set to: {}", top_args.game);
 
-    let result: i32 = match opts.subcommand {
-        CLISubcommand::Install(args) => features::install::run(args),
-        CLISubcommand::Uninstall(args) => features::uninstall::run(args),
-        CLISubcommand::Update(args) => features::update::run(args),
-        CLISubcommand::List(args) => features::list::run(args),
-        CLISubcommand::Outdated(args) => features::outdated::run(args)
+    let passed_args = top_args.clone();
+
+    let result: i32 = match top_args.subcommand {
+        CLISubcommand::Install(args) => features::install::run(passed_args, args),
+        CLISubcommand::Uninstall(args) => features::uninstall::run(passed_args, args),
+        CLISubcommand::Update(args) => features::update::run(passed_args, args),
+        CLISubcommand::List(args) => features::list::run(passed_args, args),
+        CLISubcommand::Outdated(args) => features::outdated::run(passed_args, args)
     };
 
     process::exit(result);


### PR DESCRIPTION
Breakdown:
- `cmd.rs` defines the whole command line interface. Yes, with structs, enums and a bunch of derives.
- `main.rs` defines the program entry point. 
- `features/` defines an entrypoint for each of the subcommands, each composed of a run function that takes the top-level arguments and the subcommand's corresponding arguments and returns an exit code for the program.
